### PR TITLE
Allow users to pass in phrase

### DIFF
--- a/lib/heart_of_a_developer.rb
+++ b/lib/heart_of_a_developer.rb
@@ -37,8 +37,9 @@ class HeartOfADeveloper
   ].freeze
   LINE_LENGTHS = [25, 23, 19, 15].freeze
 
-  def self.speak
-    puts illustration(partition_phrase(sample_phrase))
+  def self.speak(user_phrase = nil)
+    phrase_to_output = user_phrase || sample_phrase
+    puts illustration(partition_phrase(phrase_to_output))
   end
 
   def self.sample_phrase

--- a/lib/heart_of_a_developer.rb
+++ b/lib/heart_of_a_developer.rb
@@ -37,8 +37,7 @@ class HeartOfADeveloper
   ].freeze
   LINE_LENGTHS = [25, 23, 19, 15].freeze
 
-  def self.speak(user_phrase = nil)
-    phrase_to_output = user_phrase || sample_phrase
+  def self.speak(phrase_to_output = sample_phrase)
     puts illustration(partition_phrase(phrase_to_output))
   end
 


### PR DESCRIPTION
Users can now pass in a phrase to output by passing a string to #speak like so as referenced in #1:
`HeartOfADeveloper.speak("catchy phrase")`

